### PR TITLE
Implements Holiday dates as NaiveDate from Chrono

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,8 +41,9 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "brasilapi-client"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
+ "chrono",
  "env_logger",
  "futures",
  "futures-await-test",
@@ -77,6 +78,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -451,6 +465,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi",
+ "winapi",
+]
+
+[[package]]
 name = "tinyvec"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,6 +825,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wepoll-ffi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "brasilapi-client"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Renan Vizza Campos <renanvcampos@gmail.com>"]
 description = "Rust client implementation to consume BrasilAPI"
 repository = "https://github.com/rvcampos/brasilapi-client-rust"
@@ -21,6 +21,7 @@ isahc = "1.5"
 log = "0.4"
 regex = "1"
 lazy_static = "1.4"
+chrono = "0.4"
 
 [dev-dependencies]
 env_logger = "0.9"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ TODO
 Implemented
 
 ### National Holidays - (Brasil) 
-Partial Implemented -> Dates are being treated as STRINGS
+Implemented
 
 ### FIPE
 TODO

--- a/src/definitions/cep.rs
+++ b/src/definitions/cep.rs
@@ -131,6 +131,14 @@ mod tests {
     }
 
     #[async_test]
+    async fn test_invalid_cep() {
+        let resp = cli().get_cep("12345678", None)
+        .await;
+
+        assert!(resp.is_err());
+    }
+
+    #[async_test]
     async fn test_valid_none_ver() {
         let resp = cli().get_cep("01402-000", None).await;
         assert!(resp.is_ok());

--- a/src/definitions/holidays.rs
+++ b/src/definitions/holidays.rs
@@ -8,7 +8,7 @@ Data contract for Brasil holidays
  */
 pub struct HolidaysResponseData {
     /// The holiday date
-    pub date : String,
+    pub date : chrono::NaiveDate,
     /// The holiday name
     pub name: String,
     /// The holiday type


### PR DESCRIPTION
Since the dates was being parsed as strings, I implemented a chrono serde handler to parse them as NaiveDate (chrono's version of a DateOnly struct). This PR also includes a test for invalid CEPs.